### PR TITLE
Fix ValidationError: CSS Loader Invalid Options.

### DIFF
--- a/tutorial-bootstrap-style-js/webpack.config.js
+++ b/tutorial-bootstrap-style-js/webpack.config.js
@@ -19,8 +19,6 @@ module.exports = {
               url: false,
               // ソースマップの利用有無
               sourceMap: true,
-              // 空白文字を取り除く
-              minimize: true,
               // Sass+PostCSSの場合は2を指定
               importLoaders: 2
             },


### PR DESCRIPTION
Fix ValidationError: CSS Loader Invalid Options.

css-loaderがv1.0.0で`minimize`オプションを削除（ https://github.com/webpack-contrib/css-loader/releases/tag/v1.0.0 ）。このため、`npx webpack`を実行すると、次のようなエラーを出力してしまいます。

```
Hash: de2628d295de268575b0
Version: webpack 4.32.0
Time: 4570ms
Built at: 2019/05/25 12:04:40
 2 assets
Entrypoint main = main.js main.js.map
[0] ./src/index.js 79 bytes {0} [built]
[4] (webpack)/buildin/global.js 472 bytes {0} [built]
[5] ./src/index.scss 1.45 KiB [built] [failed] [1 error]
    + 3 hidden modules

ERROR in ./src/index.scss
Module build failed (from ./node_modules/css-loader/dist/cjs.js):
ValidationError: CSS Loader Invalid Options

options should NOT have additional properties

    at validateOptions (/Users/miyohide/work/webpack_bootstrap/node_modules/schema-utils/src/validateOptions.js:32:11)
    at Object.loader (/Users/miyohide/work/webpack_bootstrap/node_modules/css-loader/dist/index.js:44:28)
 @ ./src/index.js 4:0-21

ERROR in ./src/index.scss
Module build failed (from ./node_modules/extract-text-webpack-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/css-loader/dist/cjs.js):
ValidationError: CSS Loader Invalid Options

options should NOT have additional properties

    at validateOptions (/Users/miyohide/work/webpack_bootstrap/node_modules/schema-utils/src/validateOptions.js:32:11)
    at Object.loader (/Users/miyohide/work/webpack_bootstrap/node_modules/css-loader/dist/index.js:44:28)
    at /Users/miyohide/work/webpack_bootstrap/node_modules/webpack/lib/NormalModule.js:302:20
    at /Users/miyohide/work/webpack_bootstrap/node_modules/loader-runner/lib/LoaderRunner.js:367:11
    at /Users/miyohide/work/webpack_bootstrap/node_modules/loader-runner/lib/LoaderRunner.js:233:18
    at runSyncOrAsync (/Users/miyohide/work/webpack_bootstrap/node_modules/loader-runner/lib/LoaderRunner.js:143:3)
    at iterateNormalLoaders (/Users/miyohide/work/webpack_bootstrap/node_modules/loader-runner/lib/LoaderRunner.js:232:2)
    at iterateNormalLoaders (/Users/miyohide/work/webpack_bootstrap/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /Users/miyohide/work/webpack_bootstrap/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at context.callback (/Users/miyohide/work/webpack_bootstrap/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /Users/miyohide/work/webpack_bootstrap/node_modules/postcss-loader/src/index.js:197:9
 @ ./src/index.scss
Child extract-text-webpack-plugin node_modules/extract-text-webpack-plugin/dist node_modules/css-loader/dist/cjs.js??ref--4-1!node_modules/postcss-loader/src/index.js??ref--4-2!node_modules/sass-loader/lib/loader.js??ref--4-3!src/index.scss:
    Entrypoint undefined = extract-text-webpack-plugin-output-filename
    [0] ./node_modules/css-loader/dist/cjs.js??ref--4-1!./node_modules/postcss-loader/src??ref--4-2!./node_modules/sass-loader/lib/loader.js??ref--4-3!./src/index.scss 408 bytes {0} [built] [failed] [1 error]

    ERROR in ./src/index.scss (./node_modules/css-loader/dist/cjs.js??ref--4-1!./node_modules/postcss-loader/src??ref--4-2!./node_modules/sass-loader/lib/loader.js??ref--4-3!./src/index.scss)
    Module build failed (from ./node_modules/css-loader/dist/cjs.js):
    ValidationError: CSS Loader Invalid Options

    options should NOT have additional properties

        at validateOptions (/Users/miyohide/work/webpack_bootstrap/node_modules/schema-utils/src/validateOptions.js:32:11)
        at Object.loader (/Users/miyohide/work/webpack_bootstrap/node_modules/css-loader/dist/index.js:44:28)
```
とりあえずの回避策としてwebpack.config.jsから`minimize`オプションを削除しました。
